### PR TITLE
Error in calculation of threshold of frustum.

### DIFF
--- a/src/lib/dataset/generic_dataset.py
+++ b/src/lib/dataset/generic_dataset.py
@@ -29,7 +29,7 @@ from utils.ddd_utils import comput_corners_3d, alpha2rot_y, get_pc_hm
 def get_dist_thresh(calib, ct, dim, alpha):
     rotation_y = alpha2rot_y(alpha, ct[0], calib[0, 2], calib[0, 0])
     corners_3d = comput_corners_3d(dim, rotation_y)
-    dist_thresh = max(corners_3d[:,2]) - min(corners_3d[:,2]) / 2.0
+    dist_thresh = (max(corners_3d[:,2]) - min(corners_3d[:,2])) / 2.0
     return dist_thresh
 
 

--- a/src/lib/model/losses.py
+++ b/src/lib/model/losses.py
@@ -155,20 +155,9 @@ def compute_res_loss(output, target):
     return F.smooth_l1_loss(output, target, reduction='mean')
 
 def compute_bin_loss(output, target, mask):
-    """
-    Compute loss from classifying if angle is in this bin or in the other bin with cross entropy.
-    Use the prediction if its in this bin (=1) AND if its in the other bin (=0) because bins overlap
-    and the angle can be in both bins.
-    Mask predictions by wether or not the annotations even have a gt angle labeled or not.
-    Don't learn from making a prediction when there is no target.
-    """
-    nonzero_idx = mask.nonzero()[:,0].long()
-    if nonzero_idx.shape[0] > 0: # if there are any annotations with a labeled angle
-      output_nz = output.index_select(0, nonzero_idx)
-      target_nz = target.index_select(0, nonzero_idx)
-      return F.cross_entropy(output_nz, target_nz, reduction='mean') 
-    else: # loss would be NaN if computed normally when no annotation is given 
-      return torch.tensor(0.0).cuda() # set to different grad_fn but not relevant since loss is zero
+    mask = mask.expand_as(output)
+    output = output * mask.float()
+    return F.cross_entropy(output, target, reduction='mean')
 
 def compute_rot_loss(output, target_bin, target_res, mask):
     # output: (B, 128, 8) [bin1_cls[0], bin1_cls[1], bin1_sin, bin1_cos, 

--- a/src/lib/model/losses.py
+++ b/src/lib/model/losses.py
@@ -155,9 +155,20 @@ def compute_res_loss(output, target):
     return F.smooth_l1_loss(output, target, reduction='mean')
 
 def compute_bin_loss(output, target, mask):
-    mask = mask.expand_as(output)
-    output = output * mask.float()
-    return F.cross_entropy(output, target, reduction='mean')
+    """
+    Compute loss from classifying if angle is in this bin or in the other bin with cross entropy.
+    Use the prediction if its in this bin (=1) AND if its in the other bin (=0) because bins overlap
+    and the angle can be in both bins.
+    Mask predictions by wether or not the annotations even have a gt angle labeled or not.
+    Don't learn from making a prediction when there is no target.
+    """
+    nonzero_idx = mask.nonzero()[:,0].long()
+    if nonzero_idx.shape[0] > 0: # if there are any annotations with a labeled angle
+      output_nz = output.index_select(0, nonzero_idx)
+      target_nz = target.index_select(0, nonzero_idx)
+      return F.cross_entropy(output_nz, target_nz, reduction='mean') 
+    else: # loss would be NaN if computed normally when no annotation is given 
+      return torch.tensor(0.0).cuda() # set to different grad_fn but not relevant since loss is zero
 
 def compute_rot_loss(output, target_bin, target_res, mask):
     # output: (B, 128, 8) [bin1_cls[0], bin1_cls[1], bin1_sin, bin1_cos, 

--- a/src/lib/utils/pointcloud.py
+++ b/src/lib/utils/pointcloud.py
@@ -201,7 +201,7 @@ def comput_corners_3d(dim, rotation_y):
 def get_dist_thresh(calib, ct, dim, alpha):
     rotation_y = alpha2rot_y(alpha, ct[0], calib[0, 2], calib[0, 0])
     corners_3d = comput_corners_3d(dim, rotation_y)
-    dist_thresh = max(corners_3d[:,2]) - min(corners_3d[:,2]) / 2.0
+    dist_thresh = (max(corners_3d[:,2]) - min(corners_3d[:,2])) / 2.0
     return dist_thresh
 
 


### PR DESCRIPTION
There were parantheses missing to calculate the mean of min and max. Therefore the frustum was always too large. The expansion factor delta, which in the paper was argued to need to be greater than zero, is set to zero by default. The error in the frustum threshold calculation leads to this choice of delta making more sense. 

Although this seems to be a straight hickup, we found that calculating it correctly worsens the performance even if we set the expansion factor to a value such that the frustum is approximately as big as before. The relationship of the frustum size and the network's performance needs to be investigated more. For now, this calculation is in our view an error and the frustum size should be controlled by the expansion factor instead.